### PR TITLE
feat: add activePreviousDot option to highlight previous dots

### DIFF
--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -54,11 +55,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -215,6 +215,15 @@ class MyAppState extends State<MyApp> {
                   animate: true,
                 ),
               ]),
+              _buildRow([
+                const Text('Active Previous Dot'),
+                DotsIndicator(
+                  dotsCount: _totalDots,
+                  position: _currentPosition,
+                  activePreviousDot: true,
+                  decorator: decorator,
+                ),
+              ]),
             ],
           ),
         ),

--- a/lib/src/dots_indicator.dart
+++ b/lib/src/dots_indicator.dart
@@ -29,6 +29,8 @@ class DotsIndicator extends StatelessWidget {
   /// Duration of the animation when the position changes.
   final Duration animationDuration;
 
+  final bool activePreviousDot;
+
   DotsIndicator({
     super.key,
     required this.dotsCount,
@@ -43,6 +45,7 @@ class DotsIndicator extends StatelessWidget {
     this.fadeOutDistance = 0,
     this.animate = false,
     this.animationDuration = const Duration(milliseconds: 200),
+    this.activePreviousDot = false,
   })  : assert(dotsCount > 0, 'dotsCount must be superior to zero'),
         assert(position >= 0.0, 'position must be superior or equals to zero'),
         assert(
@@ -99,7 +102,9 @@ class DotsIndicator extends StatelessWidget {
     final double absPositionIndexRelation = (position - index).abs();
     final bool isCurrentlyVisible = absPositionIndexRelation <= fadeOutDistance;
 
-    final double lerpValue = min(1.0, absPositionIndexRelation).toDouble();
+    final double lerpValue = activePreviousDot && index <= position
+        ? 0.0 // Set lerpValue to 0 for active state
+        : min(1.0, absPositionIndexRelation).toDouble();
 
     Size size = Size.lerp(
       decorator.getActiveSize(index),
@@ -142,7 +147,8 @@ class DotsIndicator extends StatelessWidget {
                 : decorator.spacing,
             decoration: ShapeDecoration(
               color: Color.lerp(
-                decorator.getActiveColor(index) ?? Theme.of(context).primaryColor,
+                decorator.getActiveColor(index) ??
+                    Theme.of(context).primaryColor,
                 decorator.getColor(index),
                 lerpValue,
               ),


### PR DESCRIPTION
- Add activePreviousDot parameter to DotsIndicator widget
- When activePreviousDot is true, all dots with index <= position will use activeColor
- Default value is false to maintain backward compatibility
- Update comments to English for better internationalization

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Plus - 2025-07-17 at 14 20 50" src="https://github.com/user-attachments/assets/f46a39f6-6e2a-4b6a-930f-ffcb64e0dea0" />
